### PR TITLE
argusCamera: add the skeleton of the device

### DIFF
--- a/cpp/yarp-device-argus/CMakeLists.txt
+++ b/cpp/yarp-device-argus/CMakeLists.txt
@@ -1,0 +1,66 @@
+# Copyright (C) 2006-2024 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#W
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+cmake_minimum_required(VERSION 3.12)
+project(yarp-device-argus
+        LANGUAGES CXX
+        VERSION 0.0.0)
+
+include(FeatureSummary)
+
+find_package(YCM 0.16.2 REQUIRED)
+find_package(YARP 3.9.0 COMPONENTS os sig dev cv OPTIONAL_COMPONENTS math REQUIRED)
+# FIXME find_packge argus
+# find_package(OpenCV REQUIRED) # FIXME we need them?
+# find_package(CUDA QUIET)
+
+include(GNUInstallDirs)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
+if(MSVC)
+  set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "yarp-device-pylon is always built with dynamic plugins")
+set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build libraries as shared as opposed to static")
+
+include(AddInstallRPATHSupport)
+add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"
+                          LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"
+                          INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
+                          USE_LINK_PATH)
+
+if(NOT CMAKE_CONFIGURATION_TYPES)
+    if(NOT CMAKE_BUILD_TYPE)
+        message(STATUS "Setting build type to 'Release' as none was specified.")
+        set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+    endif()
+endif()
+
+set_property(GLOBAL PROPERTY USE_FOLDERS 1)
+# option(TRY_ACTIVATE_CUDA "Try to compile with CUDA" OFF) FIXME we need it?
+
+include(AddUninstallTarget)
+
+
+set(CMAKE_C_FLAGS "${YARP_C_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${YARP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+
+yarp_configure_plugins_installation(yarp-device-argus)
+
+feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES)
+
+add_subdirectory(argusCamera)

--- a/cpp/yarp-device-argus/README.md
+++ b/cpp/yarp-device-argus/README.md
@@ -1,0 +1,110 @@
+
+![YARP logo](https://raw.githubusercontent.com/robotology/yarp/master/doc/images/yarp-robot-24.png "yarp-device-argus")
+yarp-device-argus
+=================
+
+This is the [argus](FIXME) device for [YARP](https://www.yarp.it/).
+It supports the FIXME
+
+The **FRAMOS™** cameras currently compatible with YARP are:
+- FIXME
+
+# 1. License
+-------
+
+[![License](https://img.shields.io/badge/license-BSD--3--Clause%20%2B%20others-19c2d8.svg)](https://github.com/robotology/yarp-device-realsense2/blob/master/LICENSE)
+
+This software may be modified and distributed under the terms of the
+BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+The argusCamera device uses the
+[argus]FIXME sdk, released
+under the [argus license](https://docs.baslerweb.com/licensing-information).
+See the relative documentation for the terms of the license.
+
+# 2. How to use argus cameras as a YARP device
+
+## 2.1. Dependencies
+Before proceeding further, please install the following dependencies:
+- FIXME
+
+## 2.2. Build and install yarp-device-argus
+
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=<installation_path> ..
+make
+make install
+```
+In order to make the device detectable, add `<installation_path>/share/yarp` to the `YARP_DATA_DIRS` environment variable of the system.
+
+Alternatively, if `YARP` has been installed using the [robotology-superbuild](https://github.com/robotology/robotology-superbuild), it is possible to use `<directory-where-you-downloaded-robotology-superbuild>/build/install` as the `<installation_path>`.
+
+## 2.3. How to run argusCamera driver
+
+
+FIXME remove subdevice clauses
+
+From command line:
+
+```bash
+yarpdev --device frameGrabber_nws_yarp --subdevice argusCamera --name /right_cam --period 0.033 --width 640 --height 480 --rotation 90.0
+```
+
+or
+
+```
+yarpdev --from argusConf.ini
+```
+
+Where `argusConf.ini`:
+
+```ini
+device frameGrabber_nws_yarp
+subdevice argusCamera
+name /right_cam
+period 0.033
+width 640
+height 480
+rotation 90.0
+```
+
+
+This is instead the minimum number of parameters for running the device, the default nws is `frameGrabber_nws_yarp`:
+```
+yarpdev --device argusCamera
+```
+
+# 3. Device documentation
+This device driver exposes the `yarp::dev::IFrameGrabberImage` and
+`yarp::dev::IFrameGrabberControls` interfaces to read the images and operate on
+the available settings.
+See the documentation for more details about each interface.
+
+| YARP device name | YARP default nws        |
+|:----------------:|:-----------------------:|
+| `argusCamera`    | `frameGrabber_nws_yarp` |
+
+FIXME: add parameters table from the param parser generator
+
+**Suggested resolutions**
+
+FIXME
+
+|resolution|carrier|fps|
+|-|-|-|
+|640x480|mjpeg|30|
+|1024x768|mjpeg|30|
+|1920x1080|mjpeg|30 (Xavier NX) - 20 (Nano)|
+
+# 4. Informations for developers
+
+
+Maintainers
+--------------
+This repository is maintained by:
+
+| | | | |
+|:---:|:---:|:---:|:---:|
+| [<img src="https://github.com/Nicogene.png" width="40">](https://github.com/Nicogene) | [@Nicogene](https://github.com/Nicogene) | [<img src="https://github.com/martinaxgloria.png" width="40">](https://github.com/martinaxgloria) | [@martinaxgloria](https://github.com/martinaxgloria) |

--- a/cpp/yarp-device-argus/argusCamera/CMakeLists.txt
+++ b/cpp/yarp-device-argus/argusCamera/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright (C) 2006-2024 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+yarp_prepare_plugin(argusCamera
+  CATEGORY device
+  TYPE argusCameraDriver
+  INCLUDE argusCameraDriver.h
+  EXTRA_CONFIG WRAPPER=frameGrabber_nws_yarp
+  # DEPENDS "pylon_FOUND" FIXME depends argus FOUND
+  DEFAULT ON
+)
+
+# FIXME: param parser genrator?
+
+if(ENABLE_argusCamera)
+  yarp_add_plugin(yarp_argusCamera)
+
+  target_sources(yarp_argusCamera
+    PRIVATE
+      argusCameraDriver.cpp
+      argusCameraDriver.h
+  )
+
+#   list(APPEND OPENCV_DEPS  opencv_core
+#                            opencv_video
+#                            opencv_imgproc)
+
+  if (CUDA_FOUND AND OpenCV_CUDA_VERSION AND TRY_ACTIVATE_CUDA)
+    target_compile_definitions(yarp_argusCamera PUBLIC -DUSE_CUDA)
+  endif()
+
+  target_link_libraries(yarp_argusCamera
+    PUBLIC
+      YARP::YARP_os
+      YARP::YARP_sig
+      YARP::YARP_dev
+      YARP::YARP_cv
+    # FIXME argus libs
+    # FIXME opencv libs
+  )
+
+  yarp_install(
+    TARGETS yarp_argusCamera
+    EXPORT yarp-device-pylon
+    COMPONENT yarp-device-pylon
+    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+    YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR}
+  )
+
+  set_property(TARGET yarp_argusCamera PROPERTY FOLDER "Plugins/Device")
+endif()

--- a/cpp/yarp-device-argus/argusCamera/argusCameraDriver.cpp
+++ b/cpp/yarp-device-argus/argusCamera/argusCameraDriver.cpp
@@ -1,0 +1,518 @@
+/*
+ * Copyright (C) 2006-2024 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// #include <opencv2/core/core_c.h>
+// #include <yarp/cv/Cv.h>
+#include <yarp/os/LogComponent.h>
+#include <yarp/os/Value.h>
+#include <yarp/sig/ImageUtils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+// #include <opencv2/opencv.hpp>
+// #include <opencv2/videoio.hpp>
+#if defined USE_CUDA
+// #include <opencv2/cudawarping.hpp>
+#endif  // USE_CUDA
+
+#include "argusCameraDriver.h"
+
+using namespace yarp::dev;
+using namespace yarp::sig;
+using namespace yarp::os;
+
+using namespace std;
+
+// VERY IMPORTANT ABOUT WHITE BALANCE: the YARP interfaces cannot allow to set a feature with
+// 3 values, 2 is maximum and until now we always used blue and red in this order. Then we ignore
+// green
+
+static const std::vector<cameraFeature_id_t> supported_features{YARP_FEATURE_BRIGHTNESS, YARP_FEATURE_EXPOSURE, YARP_FEATURE_SHARPNESS, YARP_FEATURE_WHITE_BALANCE,
+                                                                // YARP_FEATURE_GAMMA, // it seems not writable
+                                                                YARP_FEATURE_GAIN,
+                                                                // YARP_FEATURE_TRIGGER, // not sure how to use it
+                                                                YARP_FEATURE_FRAME_RATE};
+
+static const std::vector<cameraFeature_id_t> features_with_auto{YARP_FEATURE_EXPOSURE, YARP_FEATURE_WHITE_BALANCE, YARP_FEATURE_GAIN};
+
+// Values taken from the balser documentation for IMX415-C FIXME! TO BE CHECKED!
+static const std::map<cameraFeature_id_t, std::pair<double, double>> featureMinMax{{YARP_FEATURE_BRIGHTNESS, {-1.0, 1.0}},
+                                                                                   {YARP_FEATURE_EXPOSURE, {68.0, 2300000.0}},
+                                                                                   {YARP_FEATURE_SHARPNESS, {0.0, 1.0}},
+                                                                                   {YARP_FEATURE_WHITE_BALANCE, {1.0, 8.0}},  // not sure about it, the doc is not clear, found empirically
+                                                                                   //{YARP_FEATURE_GAMMA, {0.0, 4.0}},
+                                                                                   {YARP_FEATURE_GAIN, {0.0, 33.06}}};
+
+//static const std::map<double, int> rotationToCVRot{{90.0, ROTATE_90_CLOCKWISE}, {-90.0, ROTATE_90_COUNTERCLOCKWISE}, {180.0, ROTATE_180}};
+
+// We usually set the features through a range between 0 an 1, we have to translate it in meaninful value for the camera
+double fromZeroOneToRange(cameraFeature_id_t feature, double value)
+{
+    return value * (featureMinMax.at(feature).second - featureMinMax.at(feature).first) + featureMinMax.at(feature).first;
+}
+
+// We want the features in the range 0 1
+double fromRangeToZeroOne(cameraFeature_id_t feature, double value)
+{
+    return (value - featureMinMax.at(feature).first) / (featureMinMax.at(feature).second - featureMinMax.at(feature).first);
+}
+
+bool argusCameraDriver::setFramerate(const float _fps)
+{
+    auto res = setOption("AcquisitionFrameRate", _fps);
+    if (res)
+    {
+        m_fps = _fps;
+    }
+    return res;
+}
+
+bool parseUint32Param(std::string param_name, std::uint32_t& param, yarp::os::Searchable& config)
+{
+    if (config.check(param_name) && config.find(param_name).isInt32())
+    {
+        param = config.find(param_name).asInt32();
+        return true;
+    }
+    else
+    {
+        yCWarning(ARGUS_CAMERA) << param_name << "parameter not specifie, using" << param;
+        return false;
+    }
+}
+
+bool argusCameraDriver::startCamera()
+{
+    return true;
+}
+
+bool argusCameraDriver::stopCamera()
+{
+    return true;
+}
+
+bool argusCameraDriver::open(Searchable& config)
+{
+    bool ok{true};
+    yCTrace(ARGUS_CAMERA) << "input params are " << config.toString();
+
+    // FIXME parse generator part
+
+    if (m_rotationWithCrop)
+    {
+        if (m_rotation == -90.0 || m_rotation == 90.0)
+        {
+            std::swap(m_width, m_height);
+        }
+        yCDebug(ARGUS_CAMERA) << "Rotation with crop";
+    }
+
+    double period = 0.0;  // FIXME we will parse it from the config
+
+    if (period != 0.0)
+    {
+        m_fps = 1.0 / period;  // the fps has to be aligned with the nws period
+    }
+
+    return ok && startCamera();
+}
+
+bool argusCameraDriver::close()
+{
+    return true;
+}
+
+int argusCameraDriver::getRgbHeight()
+{
+    return m_height;
+}
+
+int argusCameraDriver::getRgbWidth()
+{
+    return m_width;
+}
+
+bool argusCameraDriver::getRgbSupportedConfigurations(yarp::sig::VectorOf<CameraConfig>& configurations)
+{
+    yCWarning(ARGUS_CAMERA) << "getRgbSupportedConfigurations not implemented yet";
+    return false;
+}
+
+bool argusCameraDriver::getRgbResolution(int& width, int& height)
+{
+    width = m_width;
+    height = m_height;
+    return true;
+}
+
+bool argusCameraDriver::setRgbResolution(int width, int height)
+{
+    bool res = false;
+    if (width > 0 && height > 0)
+    {
+        // FIXME change the resolution
+        if (res)
+        {
+            m_width = width;
+            m_height = height;
+        }
+    }
+    return res;
+}
+
+bool argusCameraDriver::setRgbFOV(double horizontalFov, double verticalFov)
+{
+    yCWarning(ARGUS_CAMERA) << "setRgbFOV not supported";
+    return false;
+}
+
+bool argusCameraDriver::getRgbFOV(double& horizontalFov, double& verticalFov)
+{
+    yCWarning(ARGUS_CAMERA) << "getRgbFOV not supported";
+    return false;
+}
+
+bool argusCameraDriver::getRgbMirroring(bool& mirror)
+{
+    yCWarning(ARGUS_CAMERA) << "Mirroring not supported";
+    return false;
+}
+
+bool argusCameraDriver::setRgbMirroring(bool mirror)
+{
+    yCWarning(ARGUS_CAMERA) << "Mirroring not supported";
+    return false;
+}
+
+bool argusCameraDriver::getRgbIntrinsicParam(Property& intrinsic)
+{
+    yCWarning(ARGUS_CAMERA) << "getRgbIntrinsicParam not implemented yet";
+    return false;
+}
+
+bool argusCameraDriver::getCameraDescription(CameraDescriptor* camera)
+{
+    yCWarning(ARGUS_CAMERA) << "getCameraDescription not implemented yet";
+    return false;
+}
+
+bool argusCameraDriver::hasFeature(int feature, bool* hasFeature)
+{
+    cameraFeature_id_t f;
+    f = static_cast<cameraFeature_id_t>(feature);
+    if (f < YARP_FEATURE_BRIGHTNESS || f > YARP_FEATURE_NUMBER_OF - 1)
+    {
+        return false;
+    }
+
+    *hasFeature = std::find(supported_features.begin(), supported_features.end(), f) != supported_features.end();
+
+    return true;
+}
+
+bool argusCameraDriver::setFeature(int feature, double value)
+{
+    bool b = false;
+    if (!hasFeature(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature not supported!";
+        return false;
+    }
+    b = false;
+    auto f = static_cast<cameraFeature_id_t>(feature);
+    switch (f)
+    {
+        case YARP_FEATURE_BRIGHTNESS:
+            //FIXME
+            break;
+        case YARP_FEATURE_EXPOSURE:
+            //FIXME
+            break;
+        case YARP_FEATURE_SHARPNESS:
+            //FIXME
+            break;
+        case YARP_FEATURE_WHITE_BALANCE:
+            //FIXME
+            break;
+        case YARP_FEATURE_GAIN:
+            //FIXME
+            break;
+        case YARP_FEATURE_FRAME_RATE:
+            //FIXME
+            break;
+        default:
+            yCError(ARGUS_CAMERA) << "Feature not supported!";
+            return false;
+    }
+
+    return b;
+}
+
+bool argusCameraDriver::getFeature(int feature, double* value)
+{
+    bool b = false;
+    if (!hasFeature(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature not supported!";
+        return false;
+    }
+    b = false;
+    auto f = static_cast<cameraFeature_id_t>(feature);
+    switch (f)
+    {
+        case YARP_FEATURE_BRIGHTNESS:
+            //FIXME
+            break;
+        case YARP_FEATURE_EXPOSURE:
+            //FIXME
+            break;
+        case YARP_FEATURE_SHARPNESS:
+            //FIXME
+            break;
+        case YARP_FEATURE_WHITE_BALANCE:
+            b = false;
+            //FIXME
+            break;
+        case YARP_FEATURE_GAIN:
+            //FIXME
+            break;
+        case YARP_FEATURE_FRAME_RATE:
+            b = true;
+            //FIXME
+            break;
+        default:
+            yCError(ARGUS_CAMERA) << "Feature not supported!";
+            return false;
+    }
+
+    *value = fromRangeToZeroOne(f, *value);
+    yCDebug(ARGUS_CAMERA) << "In 0-1" << *value;
+    return b;
+}
+
+bool argusCameraDriver::setFeature(int feature, double value1, double value2)
+{
+    auto f = static_cast<cameraFeature_id_t>(feature);
+    auto res = true;
+    if (f != YARP_FEATURE_WHITE_BALANCE)
+    {
+        yCError(ARGUS_CAMERA) << YARP_FEATURE_WHITE_BALANCE << "is not a 2-values feature supported";
+        return false;
+    }
+
+    //FIXME set the feature
+    return res;
+}
+
+bool argusCameraDriver::getFeature(int feature, double* value1, double* value2)
+{
+    auto f = static_cast<cameraFeature_id_t>(feature);
+    auto res = true;
+    if (f != YARP_FEATURE_WHITE_BALANCE)
+    {
+        yCError(ARGUS_CAMERA) << "This is not a 2-values feature supported";
+        return false;
+    }
+
+    // FIXME
+    return res;
+}
+
+bool argusCameraDriver::hasOnOff(int feature, bool* HasOnOff)
+{
+    return hasAuto(feature, HasOnOff);
+}
+
+bool argusCameraDriver::setActive(int feature, bool onoff)
+{
+    bool b = false;
+    if (!hasFeature(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature" << feature << "not supported!";
+        return false;
+    }
+
+    if (!hasOnOff(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature" << feature << "does not have OnOff.. call hasOnOff() to know if a specific feature support OnOff mode";
+        return false;
+    }
+
+    std::string val_to_set = onoff ? "Continuous" : "Off";
+
+    switch (feature)
+    {
+        //FIXME all the autos feature to be enabled or disabled
+        case YARP_FEATURE_EXPOSURE:
+            //FIXME
+            break;
+        case YARP_FEATURE_WHITE_BALANCE:
+            //FIXME
+            break;
+        case YARP_FEATURE_GAIN:
+            //FIXME
+            break;
+        default:
+            yCError(ARGUS_CAMERA) << "Feature" << feature << "not supported!";
+            return false;
+    }
+
+    return b;
+}
+
+bool argusCameraDriver::getActive(int feature, bool* isActive)
+{
+    bool b = false;
+    if (!hasFeature(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature" << feature << "not supported!";
+        return false;
+    }
+
+    if (!hasOnOff(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature" << feature << "does not have OnOff.. call hasOnOff() to know if a specific feature support OnOff mode";
+        return false;
+    }
+
+    std::string val_to_get{""};
+
+    switch (feature)
+    {
+        case YARP_FEATURE_EXPOSURE:
+            //FIXME
+            break;
+        case YARP_FEATURE_WHITE_BALANCE:
+            //FIXME
+            break;
+        case YARP_FEATURE_GAIN:
+            //FIXME
+            break;
+        default:
+            yCError(ARGUS_CAMERA) << "Feature" << feature << "not supported!";
+            return false;
+    }
+    if (b)
+    {
+        if (val_to_get == "Continuous")
+        {
+            *isActive = true;
+        }
+        else if (val_to_get == "Off")
+        {
+            *isActive = false;
+        }
+    }
+    return b;
+}
+
+bool argusCameraDriver::hasAuto(int feature, bool* hasAuto)
+{
+    cameraFeature_id_t f;
+    f = static_cast<cameraFeature_id_t>(feature);
+    if (f < YARP_FEATURE_BRIGHTNESS || f > YARP_FEATURE_NUMBER_OF - 1)
+    {
+        return false;
+    }
+
+    *hasAuto = std::find(features_with_auto.begin(), features_with_auto.end(), f) != features_with_auto.end();
+
+    return true;
+}
+
+bool argusCameraDriver::hasManual(int feature, bool* hasManual)
+{
+    return hasFeature(feature, hasManual);
+}
+
+bool argusCameraDriver::hasOnePush(int feature, bool* hasOnePush)
+{
+    return hasAuto(feature, hasOnePush);
+}
+
+bool argusCameraDriver::setMode(int feature, FeatureMode mode)
+{
+    bool b{false};
+    if (!hasAuto(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature" << feature << "not supported!";
+        return false;
+    }
+
+    switch (mode)
+    {
+        case MODE_AUTO:
+            return setActive(feature, true);
+        case MODE_MANUAL:
+            return setActive(feature, false);
+        case MODE_UNKNOWN:
+            return false;
+        default:
+            return false;
+    }
+    return b;
+}
+
+bool argusCameraDriver::getMode(int feature, FeatureMode* mode)
+{
+    bool b{false};
+    if (!hasAuto(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature" << feature << "not supported!";
+        return false;
+    }
+    bool get_active{false};
+    b = b && getActive(feature, &get_active);
+
+    if (b)
+    {
+        if (get_active)
+        {
+            *mode = MODE_AUTO;
+        }
+        else
+        {
+            *mode = MODE_MANUAL;
+        }
+    }
+    return b;
+}
+
+bool argusCameraDriver::setOnePush(int feature)
+{
+    bool b = false;
+    if (!hasOnePush(feature, &b) || !b)
+    {
+        yCError(ARGUS_CAMERA) << "Feature" << feature << "doesn't have OnePush";
+        return false;
+    }
+
+    b = b && setMode(feature, MODE_AUTO);
+    b = b && setMode(feature, MODE_MANUAL);
+
+    return b;
+}
+
+bool argusCameraDriver::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    //FIXME
+    return true;
+}
+
+int argusCameraDriver::height() const
+{
+    return m_height;
+}
+
+int argusCameraDriver::width() const
+{
+    return m_width;
+}

--- a/cpp/yarp-device-argus/argusCamera/argusCameraDriver.h
+++ b/cpp/yarp-device-argus/argusCamera/argusCameraDriver.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2006-2024 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef ARGUS_DRIVER_H
+#define ARGUS_DRIVER_H
+
+// FIXME argus includes
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IFrameGrabberControls.h>
+#include <yarp/dev/IFrameGrabberImage.h>
+#include <yarp/dev/IRgbVisualParams.h>
+#include <yarp/os/PeriodicThread.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/sig/Matrix.h>
+#include <yarp/sig/all.h>
+
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <typeinfo>
+
+
+namespace
+{
+YARP_LOG_COMPONENT(ARGUS_CAMERA, "yarp.device.argusCamera")
+}
+
+class argusCameraDriver : public yarp::dev::DeviceDriver,
+                          public yarp::dev::IFrameGrabberControls,
+                          public yarp::dev::IFrameGrabberImage,
+                          public yarp::dev::IRgbVisualParams
+{
+   public:
+    argusCameraDriver() = default;
+    ~argusCameraDriver() override = default;
+
+    // DeviceDriver
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+
+    // IRgbVisualParams
+    int getRgbHeight() override;
+    int getRgbWidth() override;
+    bool getRgbSupportedConfigurations(yarp::sig::VectorOf<yarp::dev::CameraConfig>& configurations) override;
+    bool getRgbResolution(int& width, int& height) override;
+    bool setRgbResolution(int width, int height) override;
+    bool getRgbFOV(double& horizontalFov, double& verticalFov) override;
+    bool setRgbFOV(double horizontalFov, double verticalFov) override;
+    bool getRgbMirroring(bool& mirror) override;
+    bool setRgbMirroring(bool mirror) override;
+    bool getRgbIntrinsicParam(yarp::os::Property& intrinsic) override;
+
+    // IFrameGrabberControls
+    bool getCameraDescription(CameraDescriptor* camera) override;
+    bool hasFeature(int feature, bool* hasFeature) override;
+    bool setFeature(int feature, double value) override;
+    bool getFeature(int feature, double* value) override;
+    bool setFeature(int feature, double value1, double value2) override;
+    bool getFeature(int feature, double* value1, double* value2) override;
+    bool hasOnOff(int feature, bool* HasOnOff) override;
+    bool setActive(int feature, bool onoff) override;
+    bool getActive(int feature, bool* isActive) override;
+    bool hasAuto(int feature, bool* hasAuto) override;
+    bool hasManual(int feature, bool* hasManual) override;
+    bool hasOnePush(int feature, bool* hasOnePush) override;
+    bool setMode(int feature, FeatureMode mode) override;
+    bool getMode(int feature, FeatureMode* mode) override;
+    bool setOnePush(int feature) override;
+
+    // IFrameGrabberImage
+    bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image) override;
+    int height() const override;
+    int width() const override;
+
+   private:
+    // method
+    // inline bool setParams();
+    bool setFramerate(const float _fps);
+    template <class T>
+    bool setOption(const std::string& option, T value, bool isEnum = false)
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        // in some cases it is not used, suppressing the warning
+        YARP_UNUSED(isEnum);
+        bool ok{true};
+        stopCamera();
+        yCDebug(ARGUS_CAMERA) << "Setting " << option << "to" << value;
+        if constexpr (std::is_same<T, float>::value || std::is_same<T, double>::value)
+        {
+            // FIXME
+        }
+        else if constexpr (std::is_same<T, bool>::value)
+        {
+            // FIXME
+        }
+        else if constexpr (std::is_same<T, int>::value)
+        {
+            // FIXME
+        }
+        else if constexpr (std::is_same<T, const char*>::value)
+        {
+            if (isEnum)
+            {
+                // FIXME
+            }
+            else
+            {
+                // FIXME
+            }
+        }
+        else
+        {
+            yCError(ARGUS_CAMERA) << "Option" << option << "has a type not supported, type" << typeid(T).name();
+            startCamera();
+            return false;
+            }
+        return startCamera() && ok;
+    }
+
+    template <class T>
+    bool getOption(const std::string& option, T& value, bool isEnum = false)
+    {
+        // in some cases it is not used, suppressing the warning
+        YARP_UNUSED(isEnum);
+        if constexpr (std::is_same<T, float*>::value || std::is_same<T, double*>::value)
+        {
+            // FIXME
+            yCDebug(ARGUS_CAMERA) << "Getting" << option << "value:" << *value;
+        }
+        else if constexpr (std::is_same<T, bool*>::value)
+        {
+            // FIXME
+            yCDebug(ARGUS_CAMERA) << "Getting" << option << "value:" << *value;
+        }
+        else if constexpr (std::is_same<T, int*>::value)
+        {
+            // FIXME
+            yCDebug(ARGUS_CAMERA) << "Getting" << option << "value:" << *value;
+        }
+        else if constexpr (std::is_same<T, std::string>::value)
+        {
+            if (isEnum)
+            {
+                // FIXME
+                yCDebug(ARGUS_CAMERA) << "Getting" << option << "value:" << value;
+            }
+            else
+            {
+                // FIXME
+                yCDebug(ARGUS_CAMERA) << "Getting" << option << "value:" << value;
+            }
+        }
+        else
+        {
+            yCError(ARGUS_CAMERA) << "Option" << option << "has a type not supported, type" << typeid(T).name();
+            return false;
+        }
+        return true;
+    }
+
+    bool startCamera();
+    bool stopCamera();
+
+    mutable std::mutex m_mutex;
+
+    yarp::os::Stamp m_rgb_stamp;
+    mutable std::string m_lastError{""};
+    bool m_verbose{false};
+    bool m_initialized{false};
+    float m_fps{30.0};
+    double m_rotation{0.0};  // degrees
+    uint32_t m_width{640};
+    uint32_t m_height{480};
+    // FIXME argus camera pointer
+    bool m_rotationWithCrop{false};
+};
+#endif  // ARGUS_DRIVER_H


### PR DESCRIPTION
As per title, it is plenty of FIXME obviously,

It compiles, and it creates a loadable plugin:

```
$ yarp plugin argusCamera
Yes, this is a YARP plugin
  * library:        /home/ngenesio/robotology/robotology-superbuild/build/install/lib/yarp/yarp_argusCamera.so
  * system version: 5
  * class name:     argusCameraDriver
  * base class:     yarp::dev::DeviceDriver
```

cc @martinaxgloria 