### PR TITLE
argusCamera - Fix variables name

### DIFF
--- a/cpp/yarp-device-argus/argusCamera/argusCameraDriver.cpp
+++ b/cpp/yarp-device-argus/argusCamera/argusCameraDriver.cpp
@@ -289,7 +289,7 @@ bool argusCameraDriver::setRgbResolution(int width, int height)
         {
             if (m_rotation == -90.0 || m_rotation == 90.0)
             {
-                std::swap(m_width, m_height);
+                std::swap(width, height);
             }
         }
 


### PR DESCRIPTION
With:

- https://github.com/icub-tech-iit/study-icub-headedge/pull/119

I forgot to rename `m_width` and `m_height` into `width` and `height`. Now when the `rotation_with_crop` is set to true, the two are swapped as they should be.